### PR TITLE
removed reference to moved script file from index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,7 +63,6 @@
         <script type="text/javascript" src="ui/widgets/button.js"></script>
         <script type="text/javascript" src="ui/widgets/dropdown.js"></script>
         <script type="text/javascript" src="ui/widgets/slider.js"></script>
-        <script type="text/javascript" src="ui/widgets/wave.js"></script>
         <script type="text/javascript" src="ui/widgets/gfkpanel.js"></script>
         <script type="text/javascript" src="ui/widgets/menupanel.js"></script>
         <script type="text/javascript" src="ui/widgets/modelpanel.js"></script>


### PR DESCRIPTION
I was poking around in Inspect Element and noticed that you were referencing wave.js from ui/widgets, but it's not actually there, so I removed the reference and now the console doesn't throw any errors.